### PR TITLE
Helpers allow to convert a VC object to a map

### DIFF
--- a/src/main/kotlin/id/walt/vclib/Helpers.kt
+++ b/src/main/kotlin/id/walt/vclib/Helpers.kt
@@ -5,6 +5,9 @@ import id.walt.vclib.model.VerifiableCredential
 
 object Helpers {
 
-    fun VerifiableCredential.encode(): String = Klaxon().toJsonString(this)
+    private val klaxon = Klaxon()
+
+    fun VerifiableCredential.encode(): String = klaxon.toJsonString(this)
+    fun VerifiableCredential.toMap(): Map<String, Any> = klaxon.parse(encode())!!
     fun String.toCredential() = VcLibManager.getVerifiableCredential(this)
 }

--- a/src/test/kotlin/id/walt/vclib/HelpersTest.kt
+++ b/src/test/kotlin/id/walt/vclib/HelpersTest.kt
@@ -4,25 +4,24 @@ import com.beust.klaxon.Json
 import id.walt.vclib.Helpers.toMap
 import id.walt.vclib.model.VerifiableCredential
 import id.walt.vclib.registry.VerifiableCredentialMetadata
-import io.kotest.core.spec.style.AnnotationSpec
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 
-class HelpersTest : AnnotationSpec() {
+class HelpersTest : StringSpec({
+    "test toMap()" {
+        val dummyVcMap = DummyCredential().toMap()
 
-    data class Dummy(
-        @Json(name = "@context")
-        var context: List<String> = listOf("https://www.w3.org/2018/credentials/v1"),
+        dummyVcMap["@context"] shouldBe listOf("https://www.w3.org/2018/credentials/v1")
+        dummyVcMap["type"] shouldBe listOf("VerifiableCredential", "VerifiableAttestation", "DummyCredential")
+
+        dummyVcMap.containsKey("id") shouldBe false
+    }
+}) {
+    data class DummyCredential(
+        @Json(name = "@context") var context: List<String> = listOf("https://www.w3.org/2018/credentials/v1"),
         @Json(serializeNull = false) var id: String? = null
     ) : VerifiableCredential(type) {
-        companion object : VerifiableCredentialMetadata(type = listOf("VerifiableCredential", "VerifiableAttestation", "Dummy"));
-    }
-
-    @Test
-    fun testToMap() {
-        val dummyVcAsMap = Dummy().toMap()
-        assertEquals(listOf("https://www.w3.org/2018/credentials/v1"), dummyVcAsMap["@context"])
-        assertEquals(listOf("VerifiableCredential", "VerifiableAttestation", "Dummy"), dummyVcAsMap["type"])
-        assertFalse(dummyVcAsMap.containsKey("id"))
+        companion object :
+            VerifiableCredentialMetadata(listOf("VerifiableCredential", "VerifiableAttestation", "DummyCredential"))
     }
 }

--- a/src/test/kotlin/id/walt/vclib/HelpersTest.kt
+++ b/src/test/kotlin/id/walt/vclib/HelpersTest.kt
@@ -1,0 +1,28 @@
+package id.walt.vclib
+
+import com.beust.klaxon.Json
+import id.walt.vclib.Helpers.toMap
+import id.walt.vclib.model.VerifiableCredential
+import id.walt.vclib.registry.VerifiableCredentialMetadata
+import io.kotest.core.spec.style.AnnotationSpec
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+
+class HelpersTest : AnnotationSpec() {
+
+    data class Dummy(
+        @Json(name = "@context")
+        var context: List<String> = listOf("https://www.w3.org/2018/credentials/v1"),
+        @Json(serializeNull = false) var id: String? = null
+    ) : VerifiableCredential(type) {
+        companion object : VerifiableCredentialMetadata(type = listOf("VerifiableCredential", "VerifiableAttestation", "Dummy"));
+    }
+
+    @Test
+    fun testToMap() {
+        val dummyVcAsMap = Dummy().toMap()
+        assertEquals(listOf("https://www.w3.org/2018/credentials/v1"), dummyVcAsMap["@context"])
+        assertEquals(listOf("VerifiableCredential", "VerifiableAttestation", "Dummy"), dummyVcAsMap["type"])
+        assertFalse(dummyVcAsMap.containsKey("id"))
+    }
+}


### PR DESCRIPTION
This is useful for JWT signature as nimbus `JWTClaimsSet` builder includes null values to the serialized claims. Using the converted map remove the null attributes fising the issue.