### PR TITLE
Fix/get verifiable credential string

### DIFF
--- a/src/main/kotlin/id/walt/vclib/NestedVCs.kt
+++ b/src/main/kotlin/id/walt/vclib/NestedVCs.kt
@@ -30,9 +30,11 @@ object nestedVCsConverter : Converter {
 
     override fun toJson(value: Any): String {
         if(value is List<*> && (value.isEmpty() || value.first() is VerifiableCredential)) {
-            return "[${
-                value.map { (it as VerifiableCredential).encode() }.joinToString()
-            }]"
+            return "[${ value.joinToString {
+                it as VerifiableCredential
+                if (it.jwt != null) "\"${ it.encode() }\""
+                else it.encode()
+            } }]"
         } else {
             throw KlaxonException("Couldn't convert nested verifiable credentials to Json")
         }

--- a/src/main/kotlin/id/walt/vclib/VcLibManager.kt
+++ b/src/main/kotlin/id/walt/vclib/VcLibManager.kt
@@ -38,11 +38,7 @@ object VcLibManager {
     }
 
     fun getVerifiableCredentialString(vc: VerifiableCredential): String {
-        if(vc?.jwt != null) {
-            return "\"${vc!!.jwt!!}\""
-        } else {
-            return klaxon.toJsonString(vc)
-        }
+        return vc.jwt ?: klaxon.toJsonString(vc)
     }
 
     fun register(metadata: VerifiableCredentialMetadata, vc: KClass<out VerifiableCredential>) = VcTypeRegistry.register(metadata, vc)

--- a/src/main/kotlin/id/walt/vclib/schema/SchemaService.kt
+++ b/src/main/kotlin/id/walt/vclib/schema/SchemaService.kt
@@ -2,11 +2,8 @@ package id.walt.vclib.schema
 
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.github.victools.jsonschema.generator.*
-import id.walt.vclib.Helpers.encode
-import id.walt.vclib.model.VerifiableCredential
 import id.walt.vclib.vclist.Europass
 import id.walt.vclib.vclist.VerifiableId
-import net.pwall.json.schema.JSONSchema
 import java.util.*
 import kotlin.reflect.KClass
 
@@ -61,13 +58,4 @@ object SchemaService {
         field.getAnnotationConsideringFieldAndGetter(JsonIgnore::class.java) != null
 
     fun <T : Any> generateSchema(clazz: KClass<T>): ObjectNode = generator.generateSchema(clazz.java)
-
-    fun validate(vc: String, schema: String): Boolean {
-        val output = JSONSchema.parse(schema).validateBasic(vc)
-        output.errors?.forEach { println("${it.error} - ${it.instanceLocation}") }
-
-        return output.errors.isNullOrEmpty()
-    }
-
-    fun validate(vc: VerifiableCredential, schema: String) = validate(vc.encode(), schema)
 }

--- a/src/test/kotlin/id/walt/vclib/schema/SchemaServiceTest.kt
+++ b/src/test/kotlin/id/walt/vclib/schema/SchemaServiceTest.kt
@@ -1,12 +1,10 @@
 package id.walt.vclib.schema
 
 import com.beust.klaxon.Json
-import id.walt.vclib.Helpers.encode
 import id.walt.vclib.model.VerifiableCredential
 import id.walt.vclib.registry.VerifiableCredentialMetadata
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.shouldBe
 import java.io.File
 import id.walt.vclib.schema.SchemaService.DateTimeFormat;
 import id.walt.vclib.schema.SchemaService.JsonIgnore;
@@ -31,12 +29,5 @@ class SchemaServiceTest : StringSpec({
         val schema = SchemaService.generateSchema(DummyCredential::class).toPrettyString()
         val expected = File("src/test/resources/schemas/DummyCredential-schema.json").readText()
         schema shouldEqualJson expected
-    }
-
-    "testing schema validation" {
-        val vc = DummyCredential(issuanceDate = "2021-08-25T16:49:00Z")
-        val schema = SchemaService.generateSchema(DummyCredential::class).toPrettyString()
-        SchemaService.validate(vc, schema) shouldBe true
-        SchemaService.validate(vc.encode(), schema) shouldBe true
     }
 })


### PR DESCRIPTION
Necessary fix to be able to verify the json schema policy + schema validation is moved to ssikit as requested by @philpotisk to keep this library as light as possible