### PR TITLE
Added support of recursive references in JSON schema validation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,8 @@ dependencies {
     /* JSON */
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.1")
     implementation("com.github.victools:jsonschema-generator:4.20.0")
-    implementation("net.pwall.json:json-kotlin-schema:0.30")
+    implementation("com.networknt:json-schema-validator:1.0.66")
+    implementation("net.pwall.json:json-kotlin-schema:0.31")
     implementation("com.beust:klaxon:5.5")
 
     /* Logging */

--- a/src/main/kotlin/id/walt/vclib/schema/NetworkntSchemaValidator.kt
+++ b/src/main/kotlin/id/walt/vclib/schema/NetworkntSchemaValidator.kt
@@ -1,0 +1,15 @@
+package id.walt.vclib.schema
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.networknt.schema.JsonSchemaFactory
+import com.networknt.schema.SpecVersion
+
+class NetworkntSchemaValidator(versionFlag: SpecVersion.VersionFlag, schema: String): SchemaValidator {
+
+    private val jsonSchema = JsonSchemaFactory.getInstance(versionFlag).getSchema(schema)
+    private val mapper = ObjectMapper()
+
+    override fun validate(json: String): Set<Any> {
+        return jsonSchema.validate(mapper.readTree(json))
+    }
+}

--- a/src/main/kotlin/id/walt/vclib/schema/PWallSchemaValidator.kt
+++ b/src/main/kotlin/id/walt/vclib/schema/PWallSchemaValidator.kt
@@ -1,0 +1,10 @@
+package id.walt.vclib.schema
+
+import net.pwall.json.schema.JSONSchema
+
+class PWallSchemaValidator(schema: String): SchemaValidator {
+
+    private val jsonSchema = JSONSchema.parse(schema)
+
+    override fun validate(json: String) = jsonSchema.validateBasic(json).errors?.toSet() ?: emptySet()
+}

--- a/src/main/kotlin/id/walt/vclib/schema/SchemaService.kt
+++ b/src/main/kotlin/id/walt/vclib/schema/SchemaService.kt
@@ -6,7 +6,6 @@ import id.walt.vclib.credentials.VerifiableId
 import id.walt.vclib.credentials.VerifiablePresentation
 import id.walt.vclib.model.VerifiableCredential
 import id.walt.vclib.model.toCredential
-import net.pwall.json.schema.JSONSchema
 import java.util.*
 
 data class ValidationResult(val valid: Boolean, val errors: List<String>? = null)
@@ -74,15 +73,9 @@ object SchemaService {
             }
         })
 
-    fun validateSchema(jsonLdCredential: String, schema: String): ValidationResult {
-
-        val parsedSchema = JSONSchema.parse(schema)
-        val basicOutput = parsedSchema.validateBasic(jsonLdCredential)
-
-        val errors = basicOutput.errors?.map { it.error }
-
-        return ValidationResult(basicOutput.valid, errors)
-    }
+    fun validateSchema(jsonLdCredential: String, schema: String) = SchemaValidatorFactory.get(schema)
+        .validate(jsonLdCredential)
+        .let { ValidationResult(it.isEmpty(), it.map { error -> error.toString() }.toList()) }
 
     val vpSchema = "{\n" +
             "  \"\$schema\" : \"http://json-schema.org/draft-07/schema#\",\n" +

--- a/src/main/kotlin/id/walt/vclib/schema/SchemaValidator.kt
+++ b/src/main/kotlin/id/walt/vclib/schema/SchemaValidator.kt
@@ -1,0 +1,5 @@
+package id.walt.vclib.schema
+
+interface SchemaValidator {
+    fun validate(json: String): Set<Any>
+}

--- a/src/main/kotlin/id/walt/vclib/schema/SchemaValidatorFactory.kt
+++ b/src/main/kotlin/id/walt/vclib/schema/SchemaValidatorFactory.kt
@@ -1,0 +1,22 @@
+package id.walt.vclib.schema
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.networknt.schema.SpecVersion.VersionFlag.*
+import java.net.URI
+
+object SchemaValidatorFactory {
+
+    private val mapper = ObjectMapper()
+
+    fun get(schema: URI): SchemaValidator = get(schema.toURL().readText())
+
+    fun get(schema: String): SchemaValidator = with (mapper.readTree(schema).get("\$schema").asText()) {
+        return when {
+            contains("2019-09") -> NetworkntSchemaValidator(V201909, schema)
+            contains("draft-07") -> NetworkntSchemaValidator(V7, schema)
+            contains("draft-06") -> NetworkntSchemaValidator(V6, schema)
+            contains("draft-04") -> NetworkntSchemaValidator(V4, schema)
+            else -> PWallSchemaValidator(schema)
+        }
+    }
+}


### PR DESCRIPTION
Schema validation supports recursive references for schemas version 2019-09, Draft 07, 06 & 04